### PR TITLE
Add coap fmt format auto

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -30,6 +30,7 @@
 #define ZCOAP_VLOG(_level, _fmt, _ap){}
 #endif /*ZCOAP_LOG */
 
+
 #ifndef ZCOAP_ASSERT
 /**
  * Implementation may define a custom assert macro.

--- a/src/zcoap-server.c
+++ b/src/zcoap-server.c
@@ -1062,17 +1062,17 @@ coap_rsp(coap_req_data_t * const req, coap_code_t code, size_t nopts, const coap
     }
     // Allocate our response PDU.  Keep it on the stack if we can.
     coap_msg_t *rsp;
-#ifdef __GNUC__
-    union {
-        uint8_t opaque[alen <= ZCOAP_MAX_BUF_SIZE ? alen : 0];
-        coap_msg_t typed;
-    } sbuf;
-#else
+//#ifdef __GNUC__
+//    union {
+//        uint8_t opaque[alen <= ZCOAP_MAX_BUF_SIZE ? alen : 0];
+//        coap_msg_t typed;
+//    } sbuf;
+//#else
     union {
         uint8_t opaque[ZCOAP_MAX_BUF_SIZE];
         coap_msg_t typed;
     } sbuf;
-#endif
+//#endif
     if (alen <= ZCOAP_MAX_BUF_SIZE) {
         rsp = &sbuf.typed;
     } else if ((rsp = ZCOAP_ALLOCA(alen)) == NULL) {

--- a/src/zcoap-server.c
+++ b/src/zcoap-server.c
@@ -875,6 +875,8 @@ __attribute__((nonnull (1)))
 #endif
 coap_ack(coap_req_data_t* const req)
 {
+    uint8_t asBytes[sizeof(coap_msg_t) + COAP_MAX_TKL];
+    size_t len = sizeof(coap_msg_t);// + req->msg->tkl;
     if (   req == NULL
         || req->msg == NULL
         || req->len < sizeof(coap_msg_t)
@@ -886,13 +888,13 @@ coap_ack(coap_req_data_t* const req)
     } else if (req->msg->type != COAP_TYPE_CONFIRMABLE) {
         return; // should never land here!
     }
-    coap_msg_t ack;
-    ZCOAP_MEMCPY(&ack, req->msg, sizeof(ack));
-    ack.tkl = 0;
-    ack.type = COAP_TYPE_ACK;
-    ack.code.code_class = 0;
-    ack.code.code_detail = 0;
-    ((*req->responder)(req, sizeof(ack), &ack));
+    coap_msg_t *ack = asBytes;
+    ZCOAP_MEMCPY(ack, req->msg, len);
+    ack->tkl = 0;//req->msg->tkl;
+    ack->type = COAP_TYPE_ACK;
+    ack->code.code_class = 0;
+    ack->code.code_detail = 0;
+    ((*req->responder)(req, len, ack));
     // Note transmission of ACK to illicit non-piggy-backed
     // response behavior in coap_rsp().
     req->state.acked = true;

--- a/src/zcoap-server.c
+++ b/src/zcoap-server.c
@@ -133,7 +133,7 @@ __attribute__((const))
 #endif
 ZCOAP_HTONS(uint16_t hostshort)
 {
-    if (!host_is_little_endian) {
+    if (!host_is_little_endian()) {
         return hostshort; // no conversion necessary
     }
     uint16_t netshort;
@@ -156,7 +156,7 @@ __attribute__((const))
 #endif
 ZCOAP_HTONL(uint32_t hostlong)
 {
-    if (!host_is_little_endian) {
+    if (!host_is_little_endian()) {
         return hostlong; // no conversion necessary
     }
     uint32_t netlong;
@@ -181,7 +181,7 @@ __attribute__((const))
 #endif
 ZCOAP_HTONLL(uint64_t hostllong)
 {
-    if (!host_is_little_endian) {
+    if (!host_is_little_endian()) {
         return hostllong; // no conversion necessary
     }
     uint64_t netllong;
@@ -210,7 +210,7 @@ __attribute__((const))
 #endif
 ZCOAP_HTONH(half_t hostfloat)
 {
-    if (!host_is_little_endian) {
+    if (!host_is_little_endian()) {
         return hostfloat; // no conversion necessary
     }
     half_t netfloat;
@@ -233,7 +233,7 @@ __attribute__((const))
 #endif
 ZCOAP_HTONF(float hostfloat)
 {
-    if (!host_is_little_endian) {
+    if (!host_is_little_endian()) {
         return hostfloat; // no conversion necessary
     }
     float netfloat;
@@ -258,7 +258,7 @@ __attribute__((const))
 #endif
 ZCOAP_HTOND(ZCOAP_DOUBLE hostdouble)
 {
-    if (!host_is_little_endian) {
+    if (!host_is_little_endian()) {
         return hostdouble; // no conversion necessary
     }
     ZCOAP_DOUBLE netdouble;

--- a/src/zcoap-server.h
+++ b/src/zcoap-server.h
@@ -114,6 +114,7 @@ typedef enum coap_content_format_e {
     COAP_FMT_CWT = 61,
     COAP_FMT_MULTIPART_CORE = 62,
     COAP_FMT_CBOR_SEQ = 63,
+    COAP_FMT_FORMAT_AUTO = 72,
     COAP_FMT_COSE_ENCRYPT = 96,
     COAP_FMT_COSE_MAC = 97,
     COAP_FMT_COSE_SIGN = 98,

--- a/src/zcoap-server.h
+++ b/src/zcoap-server.h
@@ -359,7 +359,10 @@ struct coap_req_data_s {
      * implementation, this will typically be a socket file descriptor that
      * may be written for ACK and response.
      */
-    int context;
+    union {
+        void* context_ptr;
+        int context;
+    };
 
     /**
      * endpoint

--- a/src/zcoap-server.h
+++ b/src/zcoap-server.h
@@ -15,6 +15,11 @@
 #include <stddef.h>
 #include "config.h"
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 typedef enum coap_type_e {
     COAP_TYPE_CONFIRMABLE = 0,
     COAP_TYPE_NON_CONFIRMABLE = 1,
@@ -565,6 +570,7 @@ extern coap_code_t __attribute__((nonnull (1, 2, 4))) coap_process_observe_req(c
 extern coap_code_t __attribute__((nonnull (1))) coap_publish(coap_node_t * const node);
 extern coap_code_t coap_publish_all(void);
 
+extern void __attribute__((nonnull (1))) coap_ack(coap_req_data_t *req);
 extern void __attribute__((nonnull (1))) coap_rsp(coap_req_data_t *req, coap_code_t code, size_t nopts, const coap_opt_t opts[], size_t pl_len, const void *payload);
 extern void __attribute__((nonnull (1))) coap_content_rsp(coap_req_data_t *req, coap_code_t code, coap_ct_t ct, size_t pl_len, const void *payload);
 extern void __attribute__((nonnull (1))) coap_status_rsp(coap_req_data_t *req, coap_code_t code);
@@ -685,5 +691,9 @@ extern void __attribute__((nonnull (1))) coap_rx(coap_req_data_t *req, coap_node
 extern void coap_rx(coap_req_data_t* req, coap_node_t root); // <- server entry point!
 #endif
 extern coap_node_t wellknown_uri;
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif	/* ZCOAP_SERVER_H */

--- a/src/zsnprintf.h
+++ b/src/zsnprintf.h
@@ -16,11 +16,20 @@
 
 #include <stdarg.h>
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 size_t zvsnprintf(char *buf, size_t n, const char *fmt, va_list ap);
 #ifdef __GNUC__
 size_t zsnprintf(char *buf, size_t n, const char *fmt, ...) __attribute__((format (printf, 3, 4)));
 #else
 size_t zsnprintf(char* buf, size_t n, const char* fmt, ...);
+#endif
+
+#ifdef __cplusplus
+} // extern "C"
 #endif
 
 #endif	/* ZSNPRINTF_H */


### PR DESCRIPTION
Action: RESOLVE

The temperature controller coap server in V2xx will return a type COAP_FMT_FORMAT_AUTO which was not in the zcoap-server. We added that so that it is clear what type is being returned.
